### PR TITLE
Delete 'P2P msg exchange' row from table

### DIFF
--- a/principles/standards.rst
+++ b/principles/standards.rst
@@ -27,8 +27,6 @@ Table 1:  API Technology Selection Guide
 +------+----------------------------------------+------------------------------------------+--------------------------+-------------------+-----------------------------------------+
 | 4    | Private query or transactional service | Synchronous , authenticated              | REST with OpenID Connect | JSON and XML      | Grant application & acquittal reporting |
 +------+----------------------------------------+------------------------------------------+--------------------------+-------------------+-----------------------------------------+
-| 5    | Peer-to-peer message exchange          | Asynchronous, routable, secure, reliable | ebMS3/AS4 with SAML2.0   | XML               | SuperStream Rollover,  UBL e-Invoice    |
-+------+----------------------------------------+------------------------------------------+--------------------------+-------------------+-----------------------------------------+
 
 
 It is expected that the vast majority of government API services will be type 3 or 4.  Therefore we provide further detailed information on REST/JSON APIs in Building and publishing APIs and further detailed information on OpenID Connect in Securing APIs.


### PR DESCRIPTION
There are a number of reasons why this line should be deleted (or at least heavily expanded on and qualified).
- "P2P message exchange" is the wrong semantics, based on what I think you're getting at here. P2P message exchange can be done in any old way. For instance, I can send a JSON mesage to my friend John using good ol' HTTP (and implicitly all lower level protocols in the stack). That's a peer-to-peer message exchange. What I think we're really talking about here are decentralised routing protocols (however please correct me if I'm wrong).
- Assuming we are talking about DRPs, I can't see why we would suggest ebMS3/AS4 with SAML 2.0 as the 'preferred technology'. This choice violates a number of principles set out by the API design guide (e.g. simplicity), and also violates the principle of the section it is in: Ubiquitous Standards. Just because the Commonwealth is using it for SuperStream, doesn't make it ubiquitous. 
- This also raises the question of 'how decentralised' do we mean?
- At a glance, there are at least two _far_ more ubiquitous and simpler 'decentralised' protocols in common use: [Kademlia](https://en.wikipedia.org/wiki/Kademlia) or the [BitTorrent protocol/Mainline DHT](https://en.wikipedia.org/wiki/Mainline_DHT). And depending on the level of decentralisation, you could easily add DNS (federated), Tor (partial-decent) or [HWMP in IEEE 802.11s](https://en.wikipedia.org/wiki/IEEE_802.11s#Routing_protocols) or [B.A.T.M.A.N](https://en.wikipedia.org/wiki/B.A.T.M.A.N.) (fully-decent).
- It's also unclear what role (if any) government would/should play in a DRP-based system.

In short, this is a much larger issue that requires much more detail and qualification. And regardless of what kind of DRP we're specifically talking about, ebMS3/AS4 shouldn't even be one of the contenders given its complexity and lack of ubiquity.

Thoughts @monkeypants, @markmckenzie and @nokout?
