### PR TITLE
Some suggested changes to make API versioning guidance more flexible

### DIFF
--- a/build_and_publish/versioning.rst
+++ b/build_and_publish/versioning.rst
@@ -1,7 +1,13 @@
 .. versioning:
 
-Use versions
-============
+Some questions to think about when deciding whether and how to version
+========================================================
+* Who is using the API and what features are they using?  How painful will a version change be for them?
+* Can you make your API versionless?  (Many of the web's most used API's are either versionless, or have never moved passed version 1.0.  The publisher effectively guarantees complete backward compatibility.)
+* Can you create a mediation layer in the request and response pipeline that transforms requests and responses between old and new API versions?  If so, do you really need a new version in the first place?
+
+If you decide to use versions
+=============================
 
 Never release an API without a version number.
 
@@ -17,4 +23,9 @@ Good: v1, v2, v3
 Bad: v-1.1, v1.2, 1.3
 
 Maintain APIs at least one version back.
+
+Some questions to think about:
+
+* What technique will you use to define the version number?  Will you include it in the URL?  Will you check the Content Type in the Accept header of requests?
+* Will you have a versionless endpoint that points to the latest version?
 


### PR DESCRIPTION
I had to review this guide for a project.  I discovered a lot of successful API's are not really versioned.  So I humbly suggest these edits.
